### PR TITLE
Pass down the rounded version of filled.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,15 +88,17 @@ const launchCli = function launchCli(subject) {
         })
 
       playerInfo
-        .map(x => { return { CurrHP: x.CurrHP, MaxHP: x.MaxHP }; })
-        .distinctUntilChanged()
-        .subscribe(p => {
+        .map(p => {
           var percent = 0;
           if (p.MaxHP > 0) {
             percent = p.CurrHP / p.MaxHP;
           }
+          return { CurrHP: p.CurrHP, MaxHP: p.MaxHP,  filled: Math.round(percent*100) };
+				})
+        .distinctUntilChanged()
+        .subscribe(p => {
           hpMeter.label = `HP - ${p.CurrHP}`;
-          hpMeter.filled = percent * 100;
+          hpMeter.filled = p.filled;
           screen.render();
         })
     })


### PR DESCRIPTION
This was noticeably calling render too much (especially after eating something that was modifying the HP slowly), which resulted in making the mouse nearly impossible to use and a terrible delay when trying to exit.

/cc @nelix 
